### PR TITLE
Minor changes from testing install process

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ and needs.
         Django log files stored. You must create this directory if it does
         not already exist; Django won't create it for you, and it will error
         out if it doesn't exist.
+        * `MEDIA_ROOT` -- Full path to the directory where downloads and
+        user-uploaded files are stored. MARC files that are generated (e.g.,
+        to be loaded by SolrMarc) are stored here. Like `LOG_FILE_DIR`, you
+        must create this directory if it does not already exist.
     * Optional Settings, Development or Production -- These are settings you
     may need to set in a development or production environment, depending on
     circumstances. Remove the key from the JSON file if you want to use the
@@ -375,8 +379,6 @@ and needs.
     * Production Settings -- These are settings you'll probably only need to
     set in production. If your development environment is very different than
     the default setup, then you may need to set these there as well.
-        * `MEDIA_ROOT` -- Full path to the root directory where user-uploaded
-        files will be stored. Default is `<project_root>/django/sierra/media`.
         * `STATIC_ROOT` -- Full path to the location where static files are
         put when you run the `collectstatic` admin command. Note that you
         generally won't need this in development: when the `DEBUG` setting is

--- a/django/sierra/sierra/settings/base.py
+++ b/django/sierra/sierra/settings/base.py
@@ -42,11 +42,15 @@ if local_settings.get('SECRET_KEY', None) is None:
 if local_settings.get('LOG_FILE_DIR', None) is None:
     raise_setting_error('LOG_FILE_DIR')
 
+if local_settings.get('MEDIA_ROOT', None) is None:
+    raise_setting_error('MEDIA_ROOT')
+
 PROJECT_DIR = '{}'.format(Path(__file__).ancestor(3))
 
-# Path to the directory that will hold user-uploaded files. Defaults to
-# <catalog_api_root>/django/sierra/media.
-MEDIA_ROOT = local_settings.get('MEDIA_ROOT', '{}/media'.format(PROJECT_DIR))
+# Path to the directory where user-initiated downloads are stored.
+# Temporary MARC files get stored here before being loaded by SolrMarc.
+# Be sure to create this directory if it doesn't exist.
+MEDIA_ROOT = local_settings.get('MEDIA_ROOT')
 
 # Path to the directory where static files get put when you run the 
 # collectstatic admin command. Usually only matters in production.
@@ -395,7 +399,7 @@ EXPORTER_METADATA_TYPE_REGISTRY = [
 SOLRMARC_COMMAND = '../../solr/solrmarc/indexfile.sh'
 # The name of the properties file to use when running SolrMarc.
 SOLRMARC_CONFIG_FILE = local_settings.get('SOLRMARC_CONFIG_FILE',
-                                          'test_config.properties')
+                                          'dev_config.properties')
 
 # This maps DRF views to haystack connections. Only needed for views
 # that don't use the default connection.

--- a/django/sierra/sierra/settings/settings_template.json
+++ b/django/sierra/sierra/settings/settings_template.json
@@ -13,8 +13,9 @@
   "SIERRA_DB_USER": "",
   "SIERRA_DB_PASSWORD": "",
   "SIERRA_DB_HOST": "",
+  // Make sure to create the LOG_FILE_DIR and MEDIA_ROOT directories.
   "LOG_FILE_DIR": "/path/to/logfiles",
-
+  "MEDIA_ROOT": "/path/to/mediafiles",
   // **************************************************************************
   // OPTIONAL SETTINGS -- Remove any settings you don't need to define, and
   // a default value will be used. 
@@ -35,7 +36,6 @@
   // These are settings you'll probably only need to set in production, or if
   // you're changing your development setup significantly from the default. If
   // using the default development setup, simply delete all of these.
-  "MEDIA_ROOT": "/path/to/www/media",
   "STATIC_ROOT": "/path/to/www/static",
   "SITE_URL_ROOT": "/catalog-or-something/",
   "MEDIA_URL": "/media-or-something/",


### PR DESCRIPTION
Tested install process in README from start to finish on my laptop at home. Made a few minor changes to a couple of settings that I missed when we were staging this on GitLab:

* `MEDIA_ROOT` -- Initially set the default to go into the repo working directory in `django/sierra/media`, but we must have removed that directory at some point. Trying the test export in the last step of the README caused errors because the directory didn't exist. Makes more sense to leave this out of the repo working directory and allow the user to set it up locally, like we do for `LOG_FILE_DIR`. Changed the `base.py` settings file to remove the default value and updated `settings_template.json` as well to move it into the "required" section.
* `SOLRMARC_CONFIG_FILE` -- Default value still pointed to `test_config.properties`, which no longer exists. I renamed it to `dev_config.properties`.

Also updated the README to reflect these changes.