### PR TITLE
Fix AllToSolr exporter misnamed variables

### DIFF
--- a/django/sierra/export/batch_exporters.py
+++ b/django/sierra/export/batch_exporters.py
@@ -100,8 +100,8 @@ class AllToSolr(exporter.Exporter):
 
         for rt in settings.EXPORTER_ALL_TYPE_REGISTRY:
             for p_name in settings.EXPORTER_ALL_TYPE_REGISTRY[rt]:
-                export_type = models.ExportType.objects.get(pk=p_name)
-                p_class = export_type.get_exporter_class()
+                ex_type = models.ExportType.objects.get(pk=p_name)
+                p_class = ex_type.get_exporter_class()
                 self.prefetch_related.append(model_set(p_class))
                 for pr in p_class.prefetch_related:
                     field = model_set(p_class, pr)
@@ -152,16 +152,16 @@ class AllToSolr(exporter.Exporter):
                             'attached and was not a deletion.'
                             ''.format(r.get_iii_recnum()))
         for rt in div_records:
-            for process_name in settings.EXPORTER_ALL_TYPE_REGISTRY[rt]:
+            for p_name in settings.EXPORTER_ALL_TYPE_REGISTRY[rt]:
                 try:
-                    ex_type = models.ExportType.objects.get(pk=process_name)
-                    process_class = ex_type.get_exporter_class()
+                    ex_type = models.ExportType.objects.get(pk=p_name)
+                    p_class = ex_type.get_exporter_class()
                 except models.ExportType.DoesNotExist:
                     self.log('Error', 'Could not run {} {} on {}-type'
                              'records: process is not defined.'
-                             ''.format(process_type, process_name, rt))
+                             ''.format(process_type, p_name, rt))
                 else:
-                    process = process_class(self.instance.pk,
+                    process = p_class(self.instance.pk,
                         self.export_filter, self.export_type, self.options)
                     getattr(process, process_type)(div_records[rt])
     

--- a/django/sierra/export/batch_exporters.py
+++ b/django/sierra/export/batch_exporters.py
@@ -100,7 +100,7 @@ class AllToSolr(exporter.Exporter):
 
         for rt in settings.EXPORTER_ALL_TYPE_REGISTRY:
             for p_name in settings.EXPORTER_ALL_TYPE_REGISTRY[rt]:
-                export_type = models.ExportType.objects.get(pk=exporter_name)
+                export_type = models.ExportType.objects.get(pk=p_name)
                 p_class = export_type.get_exporter_class()
                 self.prefetch_related.append(model_set(p_class))
                 for pr in p_class.prefetch_related:
@@ -154,7 +154,7 @@ class AllToSolr(exporter.Exporter):
         for rt in div_records:
             for process_name in settings.EXPORTER_ALL_TYPE_REGISTRY[rt]:
                 try:
-                    ex_type = models.ExportType.objects.get(pk=exporter_name)
+                    ex_type = models.ExportType.objects.get(pk=process_name)
                     process_class = ex_type.get_exporter_class()
                 except models.ExportType.DoesNotExist:
                     self.log('Error', 'Could not run {} {} on {}-type'


### PR DESCRIPTION
Extremely simple change. Two variables in export.batch_exporters.AllToSolr methods were misnamed
(export_name), causing Django to throw an error when running the export.
Fixes issue #15.