### PR TITLE
Improve how data from Solr is queried when a shelflist.exporters.ItemsToSolr process is run

### DIFF
--- a/django/sierra/shelflist/search_indexes.py
+++ b/django/sierra/shelflist/search_indexes.py
@@ -20,11 +20,15 @@ class ShelflistItemIndex(search_indexes.ItemIndex):
     flags = indexes.MultiValueField(null=True)
     inventory_date = indexes.DateTimeField(null=True)
 
+    def __init__(self, *args, **kwargs):
+        super(ShelflistItemIndex, self).__init__(*args, **kwargs)
+        self.solr_conn = solr.connect()
+
     def prepare_shelf_status(self, obj):
         ret_val = getattr(obj, 'shelf_status', None)
         if ret_val is None:
             try:
-                item = solr.Queryset().filter(id=obj.id)[0]
+                item = solr.Queryset(conn=self.solr_conn).filter(id=obj.id)[0]
             except Exception:
                 pass
             else:
@@ -35,7 +39,7 @@ class ShelflistItemIndex(search_indexes.ItemIndex):
         ret_val = getattr(obj, 'inventory_notes', None)
         if ret_val is None:
             try:
-                item = solr.Queryset().filter(id=obj.id)[0]
+                item = solr.Queryset(conn=self.solr_conn).filter(id=obj.id)[0]
             except Exception:
                 pass
             else:
@@ -46,7 +50,7 @@ class ShelflistItemIndex(search_indexes.ItemIndex):
         ret_val = getattr(obj, 'flags', None)
         if ret_val is None:
             try:
-                item = solr.Queryset().filter(id=obj.id)[0]
+                item = solr.Queryset(conn=self.solr_conn).filter(id=obj.id)[0]
             except Exception:
                 pass
             else:
@@ -57,7 +61,7 @@ class ShelflistItemIndex(search_indexes.ItemIndex):
         ret_val = getattr(obj, 'inventory_date', None)
         if ret_val is None:
             try:
-                item = solr.Queryset().filter(id=obj.id)[0]
+                item = solr.Queryset(conn=self.solr_conn).filter(id=obj.id)[0]
             except Exception:
                 pass
             else:

--- a/django/sierra/shelflist/search_indexes.py
+++ b/django/sierra/shelflist/search_indexes.py
@@ -44,11 +44,8 @@ class ShelflistItemIndex(search_indexes.ItemIndex):
         """
         self.prepared_data = super(ShelflistItemIndex, self).prepare(obj)
         if not self.has_any_user_data(obj):
-            try:
-                item = solr.Queryset(conn=self.solr_conn).filter(id=obj.id)[0]
-            except IndexError:
-                pass
-            else:
+            item = solr.Queryset(conn=self.solr_conn).get_one(id=obj.id)
+            if item:
                 for field in self.user_data_fields:
                     self.prepared_data[field] = getattr(item, field, None)
         return self.prepared_data

--- a/django/sierra/shelflist/search_indexes.py
+++ b/django/sierra/shelflist/search_indexes.py
@@ -1,6 +1,6 @@
 """
 This contains additional specifications for the haystack Solr indexes
-for the shelflist app. 
+for the shelflist app.
 """
 from haystack import indexes
 

--- a/django/sierra/utils/solr.py
+++ b/django/sierra/utils/solr.py
@@ -1,6 +1,6 @@
-'''
+"""
 Provides Django queryset functionality on top of Solr search results.
-'''
+"""
 import re
 import copy
 from datetime import datetime
@@ -30,12 +30,12 @@ class MultipleObjectsReturned(Exception):
 
 
 class Result(dict):
-    '''
+    """
     Simple Result class that provides Solr fields as object attributes
     but is instantiated using a dict. Can be updated by manipulating
     the object attributes / dict values directly. Can be saved back to
     Solr using save().
-    '''
+    """
     def __init__(self, *args, **kwargs):
         super(Result, self).__init__(*args, **kwargs)
         self.__dict__ = self
@@ -67,7 +67,7 @@ class Queryset(object):
             start = key.start
             new_key = key.start - self._result_offset
             rows = key.stop - key.start
-            r = self._conn.search(start=start, rows=rows, 
+            r = self._conn.search(start=start, rows=rows,
                                   **self._search_params)
             self._full_response = r
             return [Result(i) for i in r]
@@ -160,8 +160,8 @@ class Queryset(object):
 
     def _add_range_parameter(self, field, val):
         return u'{}:["{}" TO "{}"]'.format(field,
-                                          self._conn._from_python(val[0]),
-                                          self._conn._from_python(val[1]))
+                                           self._conn._from_python(val[0]),
+                                           self._conn._from_python(val[1]))
 
     def _add_matches_parameter(self, field, val):
         start, end = ('.*', '.*')
@@ -190,7 +190,8 @@ class Queryset(object):
             time_str = '{:02d}:{:02d}:{:02d}'.format(*s_time[3:6])
             val = '{}T{}Z'.format(date_str, time_str)
         else:
-            val = re.sub(r'([ +\-!(){}\[\]\^"~*?:\\/]|&&|\|\|)', r'\\\1', str(val))
+            val = re.sub(r'([ +\-!(){}\[\]\^"~*?:\\/]|&&|\|\|)', r'\\\1',
+                         str(val))
         return val
 
     def _do_search_parameters(self, **kwargs):
@@ -235,7 +236,7 @@ class Queryset(object):
         returns multiple objects.
         """
         result = self.filter(**kwargs)
-        try:            
+        try:
             ret_value = result[0]
         except IndexError:
             ret_value = None


### PR DESCRIPTION
Fixes Issue #17 and otherwise improves how Solr is queried by `shelflist.search_indexes.ShelflistItemIndex` when an `ItemsToSolr` export process runs.

First, the problem with tons of HTTP connections being opened by querying Solr over and over is solved by allowing reuse of the same `pysolr.Solr` object across multiple `utils.solr.Queryset` instances.

Second, I've refactored `shelflist.search_indexes.ShelflistItemIndex` to make a minor improvement in how data is prepared for indexing. I replaced the four field `prepare_*` methods, where the same Solr query (to pull back data for the item represented by the object) was being sent once per field `prepare` method, with a single general object `prepare` method. So now Solr is queried once per item instead of four times per item.