### PR TITLE
Fix sierra-test-db fixture loading on Linux

### DIFF
--- a/init-dockerdata.sh
+++ b/init-dockerdata.sh
@@ -217,7 +217,7 @@ function migrate_sierra_db_test {
   if [[ $volume_is_ready ]]; then
     docker-compose run --rm manage-test migrate --database=sierra
     echo "Installing sierra-db-test fixtures..."
-    docker-compose run --rm manage-test loaddata --app=base --database=sierra "$(find $SIERRA_FIXTURE_PATH/*.json -exec basename {} .json \;)"
+    docker-compose run --rm manage-test loaddata --app=base --database=sierra $(find $SIERRA_FIXTURE_PATH/*.json -exec basename {} .json \; | tr '\n' ' ')
   else
     echo "Warning: Database could not be initialized; skipping migrations for \`sierra-db-test\`"
   fi


### PR DESCRIPTION
This fixes the shell command used in init-dockerdata.sh that finds and then passes args to manage-test loaddata for loading fixtures into sierra-db-test. It was working on Mac, but I noticed it was not working correctly on TravisCI Linux (even though tests were all passing). Removing the quotation marks around the `find` command and converting newlines to spaces seems to have done the trick.