### PR TITLE
Update openjdk-7-jre dependency to openjdk-8-jre in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ celerybeat-schedule
 django_sierra
 django_sierra_test
 .cache/
+.pytest_cache/
 
 /pids.txt
 /django/sierra/media/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7
 
 RUN apt-get update -qq && \
-    apt-get install -y libpq-dev python-dev mysql-client netcat openjdk-7-jre
+    apt-get install -y libpq-dev python-dev mysql-client netcat openjdk-8-jre
 
 ARG userid=999
 ARG groupid=999


### PR DESCRIPTION
The `openjdk-7-jre` dependency in the Dockerfile build is no longer available via `apt-get`, breaking the Docker development environment (and causing CI tests to fail). This updates the Dockerfile to use `openjdk-8-jre` instead.

(Incidental change: `.pytest_cache` directory is added to `.gitignore`)