### PR TITLE
Make exporter.Exporter export_records and delete_records return values work better with tasks

### DIFF
--- a/django/sierra/export/batch_exporters.py
+++ b/django/sierra/export/batch_exporters.py
@@ -57,16 +57,25 @@ class AllMetadataToSolr(exporter.Exporter):
 
 class AllToSolr(exporter.Exporter):
     """
-    Uses RecordMetadata to load ALL major III record types into Solr.
-    Set up the EXPORTER_ALL_TYPE_REGISTRY setting in your Django
-    settings to register what export jobs correspond with which record
-    types. Only registered record types will be loaded.
+    This exporter is now deprecated, please do not use.
+
+    If you need an exporter that runs multiple children exporters for
+    a single batch of records, create a class that does so explicitly.
+    From now on, `AllToSolr` will not be kept up-to-date with changes
+    to exporters and related code.
+
+    `AllToSolr` will be removed in a future update.
     """
     record_filter = []
     select_related = [
         'record_type'
     ]
     model_name = 'RecordMetadata'
+
+    def _warn(self):
+        msg = ('The `AllToSolr` exporter is deprecated and will be removed '
+               'in a future update.')
+        self.log('Warning', msg)
 
     def __init__(self, *args, **kwargs):
         """
@@ -81,6 +90,7 @@ class AllToSolr(exporter.Exporter):
         e.g. record_metadata.
         """
         super(AllToSolr, self).__init__(*args, **kwargs)
+        self._warn()
         def model_set(p_class, fieldname='', add_set=True):
             if fieldname == 'record_metadata':
                 ret_val = None

--- a/django/sierra/export/batch_exporters.py
+++ b/django/sierra/export/batch_exporters.py
@@ -39,20 +39,20 @@ class AllMetadataToSolr(exporter.Exporter):
     def get_records(self):
         return { k: v.get_records() for k, v in self.child_instances.items() }
     
-    def export_records(self, records, vals={}):
+    def export_records(self, records):
+        ret_vals = {}
         for etype_name in self.child_etype_names:
-            vals[etype_name] = vals.get(etype_name, {})
             exp_inst = self.child_instances[etype_name]
-            et_vals = exp_inst.export_records(records[etype_name],
-                                              vals=vals[etype_name])
-            vals[etype_name].update(et_vals)
-        return vals
+            et_vals = exp_inst.export_records(records[etype_name])
+            ret_vals[etype_name] = et_vals
+        return ret_vals
 
-    def final_callback(self, vals={}, status='success'):
+    def final_callback(self, vals=None, status='success'):
+        vals = vals or {}
         for etype_name in self.child_etype_names:
-            et_vals = vals.get(etype_name, {})
             exp_inst = self.child_instances[etype_name]
-            exp_inst.final_callback(vals=et_vals, status=status)
+            exp_inst.final_callback(vals=vals.get(etype_name, {}),
+                                    status=status)
 
 
 class AllToSolr(exporter.Exporter):
@@ -162,10 +162,8 @@ class AllToSolr(exporter.Exporter):
                         self.export_filter, self.export_type, self.options)
                     getattr(process, process_type)(div_records[rt])
     
-    def export_records(self, records, vals={}):
+    def export_records(self, records):
         self.dispatch_it(records, process_type='export_records')
-        return vals
 
-    def delete_records(self, records, vals={}):
+    def delete_records(self, records):
         self.dispatch_it(records, process_type='delete_records')
-        return vals

--- a/django/sierra/export/sierra2marc.py
+++ b/django/sierra/export/sierra2marc.py
@@ -1,7 +1,7 @@
-'''
+"""
 sierra2marc.py defines a class (S2MarcBatch) for parsing the Sierra
 models out into MARC21 using Pymarc.
-'''
+"""
 import re
 import codecs
 import sys
@@ -23,10 +23,10 @@ class S2MarcError(Exception):
 
 
 class S2MarcBatch(object):
-    '''
+    """
     Sierra to MARC21 Batch converter: instantiate this class to
     generate MARC21 records from a queryset of BibRecords.
-    '''
+    """
 
     cn_type_subfield_mapping = {
         'lc': 'c',
@@ -45,13 +45,13 @@ class S2MarcBatch(object):
         self.success_count = 0
 
     def _one_to_marc(self, r):
-        '''
+        """
         Converts one record to a pymarc.record.Record object. Returns
         the object. Note that the III record number is stored in 907$a
         and the database ID is stored in 907$b. Other metadata fields
         are stored in 9XXs as needed, to ease conversion from MARC to
         Solr.
-        '''
+        """
         marc_record = pymarc.record.Record(force_utf8=True)
         try:
             control_fields = r.record_metadata.controlfield_set.all()
@@ -150,10 +150,10 @@ class S2MarcBatch(object):
         return marc_record
 
     def to_marc(self):
-        '''
+        """
         Converts all self.records to pymarc record objects and
         returns an array of them. Stores errors in self.errors.
-        '''
+        """
         marc_records = []
         for r in self.records:
             try:
@@ -179,11 +179,12 @@ class S2MarcBatch(object):
                 success_count += 1
         return success_count
 
-    def to_file(self, marc_records, filename='{}.mrc'.format(timestamp()),
-                filepath='{}'.format(settings.MEDIA_ROOT), append=True):
-        '''
+    def to_file(self, marc_records, filename=None, filepath=None, append=True):
+        """
         Writes MARC21 file to disk.
-        '''
+        """
+        filename = filename or '{}.mrc'.format(timestamp())
+        filepath = filepath or '{}'.format(settings.MEDIA_ROOT)
         self.success_count = 0
         # If the file exists and append is True, we want to open the
         # file up, read in the MARC records, then append our

--- a/django/sierra/export/tests/test_exporters.py
+++ b/django/sierra/export/tests/test_exporters.py
@@ -85,7 +85,7 @@ def test_exports_to_solr(etype_code, solr_exporter_test_params, new_exporter,
     del_results = {}
     if try_delete:
         del_exporter = new_exporter(etype_code, 'full_export', 'waiting')
-        delete_records(del_exporter, record_set)
+        delete_records(del_exporter, [r.record_metadata for r in record_set])
         del_results = {c: solr_search(conns[c], {'q': '*'}) for c in cores}
 
     for core in cores:

--- a/django/sierra/shelflist/exporters.py
+++ b/django/sierra/shelflist/exporters.py
@@ -1,11 +1,11 @@
-'''
+"""
 Exporters for the Shelflist app are defined here. See export.exporter
 for the base Exporter class and export.basic_exporters for some
 implementations. Here we pretty much just need to define the
 final_callback method for item exporters so that any locations
 represented in the items have their shelflist row manifest document in
 Solr updated automatically whenever items are loaded.
-'''
+"""
 from __future__ import unicode_literals
 import logging
 import json
@@ -24,11 +24,11 @@ from . import search_indexes as indexes
 logger = logging.getLogger('sierra.custom')
 
 def index_shelflist_rows(exp):
-    '''
+    """
     This is what does the work of determining the locations that need
     to be updated (based on what locations appear in the exporter
     object's record set) and stuff.
-    '''
+    """
     exp.log('Info', 'Creating shelflist item manifests.')
     solr = pysolr.Solr(settings.HAYSTACK_CONNECTIONS[exp.hs_conn]['URL'])
     records = exp.get_records()
@@ -53,6 +53,6 @@ def index_shelflist_rows(exp):
 class ItemsToSolr(exporters.ItemsToSolr):
     max_rec_chunk = 500
     index_class = indexes.ShelflistItemIndex
-    def final_callback(self, vals={}, status='success'):
+    def final_callback(self, vals=None, status='success'):
         super(ItemsToSolr, self).final_callback(vals, status)
         index_shelflist_rows(self)


### PR DESCRIPTION
These changes are primarily geared toward ensuring that values returned by `export.Exporter` classes' `export_records` and `delete_records` methods ("vals") are handled predictably and uniformly by Celery tasks. Specifically, we now assume that the way our Celery task workflow runs exporters is the preferred way to run them: large jobs are broken into multiple chunks of export and delete operations, which are run in one or more batches of parallel tasks, with a final callback at the end. Return values from each chunk are compiled periodically and then returned to the final callback for handling at the very end.

**New Exporter Behavior**

Exporters now behave differently in the following ways.

* The `export.Exporter.parallel` attribute has been removed. You can no longer specify that something should **not** run in parallel; it's expected that everything runs in parallel, aside from callbacks.
* `export_records` and `delete_records` no longer accept a `vals` kwarg.
    * Old behavior: Originally `vals` was passed to each of these methods in order to support running them serially (i.e. via a Celery chain rather than a chord). In a serial run, return values are passed from node to node, and each node is responsible for accumulating or compiling the values from the previous node and the current one. Allowing both serial and parallel behavior led to confusion about where the responsibility for compiling return values lied and how to manage or enforce that.
    * New behavior: Now that tasks are assumed to run in parallel, it's simpler just to compile return values at the end. This eliminates the `vals` kwarg from the exporter methods that run as intermediate nodes in a job and simplifies their code since they don't need to worry about compiling vals as they go. (The `final_callback` method of course still accepts a `vals` kwarg.)
* Exporters have a new method, `compile_vals`, which defines how an array of return values (i.e. the `results` arg) collected from running a series of multiple `export_records` or `delete_records` tasks should be processed to compose the final `vals` kwarg that's passed to `final_callback`. The default implementation carries over the previous behavior, where it assumes your final `vals` argument is a dictionary and attempts to merge dictionaries (handling nested arrays and dicts recursively). But, if you have specific needs for what values you want to return and how to handle them, you can now define that behavior in a custom `compile_vals` method. (Which is way more explicit than the old behavior.)

**Fixed How Task Error-Callbacks Handle Return Values**

The changes made to tasks via the `improve-tasks` branch did not correctly handle return values with error callbacks, and this fixes that behavior. Here are the details.

When a normal chord callback runs, Celery passes the list of return values from each of the nodes as the first argument to the callback. We use this behavior to track all return values from an entire job, compile them with each `delegate_batch` callback, and eventually pass them to the `final_callback` method of the exporter.

When any tasks in the chord raise an unexpected error, the chord's error callback (`link_error`) runs instead of the normal callback. And we've used _this_ behavior to build in some fault tolerance. The error callback for each chord is the same basic callback function used as a normal callback, the idea being that Celery will continue on with the next batch (or run the final callback, if it's the last batch) despite non-fatal errors.

However, when an error callback runs, Celery passes the task IDs for tasks in the chord that raised errors **instead** of the regular return values for the successful tasks. So, when an error happens, all return values up to that point get lost if we don't explicitly handle that scenario. Fortunately, it is possible, given the task ID that spawned a chord, to use Celery to find and retrieve the list of results for successful nodes in the result backend.

So, now, the `delegate_batches` task keeps a running `cumulative_vals` variable in play and passes its own task ID to error callbacks; callbacks now check to see if they were the result of an error and rebuild the return values if needed so they can continue the job without dropping any information.

**`AllToSolr` Deprecation**

Lastly, the `export.batch_exporters.AllToSolr` class is now deprecated and will be removed in a future version. I created this exporter long before we had the Catalog API running in production, and it turns out not to be as useful as I thought it might be. Scheduling and coordinating when to load various record types is more nuanced than a simple "load everything at once" approach can accomplish. And this exporter is sufficiently unique that it's no longer worth the upkeep.
