### PR TITLE
Update Dockerfile to use working python/debian img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:2.7
+FROM python:2.7.16-stretch
 
 RUN apt-get update -qq && \
-    apt-get install -y libpq-dev python-dev mysql-client netcat openjdk-8-jre
+    apt-get install -y libpq-dev python-dev mariadb-client netcat openjdk-8-jre
 
 ARG userid=999
 ARG groupid=999


### PR DESCRIPTION
To ensure docker builds continue to work, needed to update base image to
python:2.7.16-strech, to continue using openjdk-8-jre. I tried switching
to openjdk-11-jre, but it doesn't work with the (old!) version of
Solrmarc we're using. Also, switch to mariadb-client (to replace mysql-client).